### PR TITLE
jsg_markdown looks for GITHUB_TOKEN env var

### DIFF
--- a/bin/jsg_markdown
+++ b/bin/jsg_markdown
@@ -1,6 +1,17 @@
 #!/bin/bash
+# Posts stdin to GitHub's markdown API.
+#
+# jsg_markdown
+#
+# GITHUB_TOKEN if this environment variable is set, requests are authenticated to increase the API rate limit
+#
+curl_auth=
+
+if [ -n $GITHUB_TOKEN ]; then
+  curl_auth="-H 'Authorization: token $GITHUB_TOKEN'"
+fi
 
 # markdown -> html
 # /markdown/raw endpoint is broken, using json endpoint until fixed
 ruby -rjson -e 'h = {text: $stdin.read}; puts h.to_json' \
-  | curl -s -H 'Content-Type: text/plain' https://api.github.com/markdown -d'@-'
+  | curl -s -H 'Content-Type: text/plain' $curl_auth https://api.github.com/markdown -d'@-'


### PR DESCRIPTION
When available, it makes authenticated requests.

Not testable since it works even with a bad token.
